### PR TITLE
Export the helpers in the public API for inheritance purpose

### DIFF
--- a/spec/handlebars.form-helpers.spec.js
+++ b/spec/handlebars.form-helpers.spec.js
@@ -8,6 +8,22 @@ describe('Handlebars form helpers', function() {
       expect(typeof HandlebarsFormHelpers.namespace).toBe('function');
     });
 
+    it('Has \'helpers\' object and it contains all the helpers', function() {
+      expect(typeof HandlebarsFormHelpers.helpers).toBe('object');
+
+      var helpers = [
+        'form', 'input', 'label', 'button', 'submit', 'select',
+        'checkbox', 'radio', 'file', 'hidden', 'password', 'textarea',
+        'label_validation', 'input_validation', 'select_validation', 
+        'checkbox_validation', 'radio_validation', 'file_validation', 
+        'password_validation', 'textarea_validation', 'field_errors'
+      ];
+
+      for (var i = 0, l = helpers.length; i < l; i++) {
+        expect(typeof HandlebarsFormHelpers.helpers[helpers[i]]).toBe('function');
+      }
+    });
+
     it('Sets or gets the namespace', function() {
       HandlebarsFormHelpers.namespace('test');
       expect(HandlebarsFormHelpers.namespace()).toBe('test-');

--- a/src/handlebars.form-helpers.js
+++ b/src/handlebars.form-helpers.js
@@ -323,40 +323,47 @@
   }
 
   // Register all helpers
+  var allHelpers = [
+    // Form helpers
+    [form,       helperForm],
+    [input,      helperInput],
+    [label,      helperLabel],
+    [button,     helperButton],
+    [submit,     helperSubmit],
+    [select,     helperSelect],
+    [checkbox,   helperCheckbox],
+    [radio,      helperRadio],
+    [file,       helperFile],
+    [hidden,     helperHidden],
+    [password,   helperPassword],
+    [textarea,   helperTextarea],
+    // Form validation helpers
+    [label+validationSufffix,    helperLabelValidation],
+    [input+validationSufffix,    helperInputValidation],
+    [select+validationSufffix,   helperSelectValidation],
+    [checkbox+validationSufffix, helperCheckboxValidation],
+    [radio+validationSufffix,    helperRadioValidation],
+    [file+validationSufffix,     helperFileValidation],
+    [password+validationSufffix, helperPasswordValidation],
+    [textarea+validationSufffix, helperTextareaValidation],
+    [field_errors,               helperFieldErrors]
+  ];
+
   function register(HandlebarsSrc) {
-
     Handlebars = HandlebarsSrc;
-
-    registerHelpers([
-      // Form helpers
-      [form,       helperForm],
-      [input,      helperInput],
-      [label,      helperLabel],
-      [button,     helperButton],
-      [submit,     helperSubmit],
-      [select,     helperSelect],
-      [checkbox,   helperCheckbox],
-      [radio,      helperRadio],
-      [file,       helperFile],
-      [hidden,     helperHidden],
-      [password,   helperPassword],
-      [textarea,   helperTextarea],
-      // Form validation helpers
-      [label+validationSufffix,    helperLabelValidation],
-      [input+validationSufffix,    helperInputValidation],
-      [select+validationSufffix,   helperSelectValidation],
-      [checkbox+validationSufffix, helperCheckboxValidation],
-      [radio+validationSufffix,    helperRadioValidation],
-      [file+validationSufffix,     helperFileValidation],
-      [password+validationSufffix, helperPasswordValidation],
-      [textarea+validationSufffix, helperTextareaValidation],
-      [field_errors,               helperFieldErrors]
-    ]);
+    registerHelpers(allHelpers);
   }
 
   // public API
   return {
     namespace: namespace,
-    register: register
+    register: register,
+
+    // Export all helpers for inheritance purpose
+    helpers: (function () {
+      var helpers = {};
+      for (var i = 0, l = allHelpers.length; i < l; i++) helpers[allHelpers[i][0]] = allHelpers[i][1];
+      return helpers;
+    })()
   };
 }));


### PR DESCRIPTION
In order to overwrite and inherit the helpers like this:

``` js
HandlebarsFormHelpers.register(Handlebars);
Handlebars.registerHelper('label', function (input, body, options) {
  body = doSomeThingLikeTraduction(body);
  HandlebarsFormHelpers.helpers.label.apply(this, [ input, body, options ]);
});
```

It would be fine to add project specific mechanism.

I do not know if the tests are carried out in the best way.
