### PR TITLE
Using handlebars against handlebars.js

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "handlebars-form-helpers",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "main": "dist/handlebars.form-helpers.min.js",
   "ignore": [
     "node_modules"

--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "node_modules"
   ],
   "dependencies": {
-    "handlebars": "~1.0.11"
+    "handlebars": "~3.0.3"
   },
   "devDependencies": {
     "bootstrap": "~2.3.1",

--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "node_modules"
   ],
   "dependencies": {
-    "handlebars.js": "~1.0.11"
+    "handlebars": "~1.0.11"
   },
   "devDependencies": {
     "bootstrap": "~2.3.1",


### PR DESCRIPTION
Hi,

Like explains in handlebars web site, it's better to use "handlebars" dependency against "handlebars.js" : http://handlebarsjs.com/installation.html

Moreover "handlebars.js" dep retrieves a lot of unnecessary files and that's not include minified handlebars script version.